### PR TITLE
10: add peer dependencies for react packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,7 @@
       "dependencies": {
         "jest-environment-jsdom": "29.7.0",
         "js-cookie": "3.0.5",
-        "react": "18.3.1",
-        "react-dom": "18.3.1",
-        "react-ga4": "2.1.0",
-        "react-router-dom": "6.28.2"
+        "react-ga4": "2.1.0"
       },
       "devDependencies": {
         "@babel/core": "7.25.2",
@@ -30,6 +27,11 @@
         "jest": "29.7.0",
         "ts-jest": "29.2.5",
         "typescript": "5.6.3"
+      },
+      "peerDependencies": {
+        "react": "18.x",
+        "react-dom": "18.x",
+        "react-router-dom": "6.x"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2286,6 +2288,7 @@
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.21.1.tgz",
       "integrity": "sha512-KeBYSwohb8g4/wCcnksvKTYlg69O62sQeLynn2YE+5z7JWEj95if27kclW9QqbrlsQ2DINI8fjbV3zyuKfwjKg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -4997,6 +5000,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "peer": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -5434,6 +5438,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5445,6 +5450,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5470,6 +5476,7 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.28.2.tgz",
       "integrity": "sha512-BgFY7+wEGVjHCiqaj2XiUBQ1kkzfg6UoKYwEe0wv+FF+HNPCxtS/MVPvLAPH++EsuCMReZl9RYVGqcHLk5ms3A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@remix-run/router": "1.21.1"
       },
@@ -5485,6 +5492,7 @@
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.28.2.tgz",
       "integrity": "sha512-O81EWqNJWqvlN/a7eTudAdQm0TbI7hw+WIi7OwwMcTn5JMyZ0ibTFNGz+t+Lju0df4LcqowCegcrK22lB1q9Kw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@remix-run/router": "1.21.1",
         "react-router": "6.28.2"
@@ -5662,6 +5670,7 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -36,10 +36,7 @@
   "dependencies": {
     "jest-environment-jsdom": "29.7.0",
     "js-cookie": "3.0.5",
-    "react": "18.3.1",
-    "react-dom": "18.3.1",
-    "react-ga4": "2.1.0",
-    "react-router-dom": "6.28.2"
+    "react-ga4": "2.1.0"
   },
   "devDependencies": {
     "@babel/core": "7.25.2",
@@ -55,5 +52,10 @@
     "jest": "29.7.0",
     "ts-jest": "29.2.5",
     "typescript": "5.6.3"
+  },
+  "peerDependencies": {
+    "react": "18.x",
+    "react-dom": "18.x",
+    "react-router-dom": "6.x"
   }
 }


### PR DESCRIPTION
uses semver to name the react packages such that the host project matches the major version at least.